### PR TITLE
the "improved" app adder script.

### DIFF
--- a/gnome-app-adder.sh
+++ b/gnome-app-adder.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#Collecting infos via zenity
+PROGRAM="xdg-open "
+TERMINAL=false
+if ! NAME="$(zenity --entry --text "Name of the Application" --title "Name")"; then
+  exit;
+fi
+echo $NAME
+echo "file name ok"
+if ! EXEC=$(zenity --file-selection --title="Choose the file"); then
+    exit;
+fi
+echo "exec ok"
+if ! ICON=$(zenity --file-selection --title="Choose the Icon")
+	 then
+		if [[ $ICON=="" ]]
+			then
+	 		echo "No icon selected, chosing default icon (only works on GNOME so far)" #TODO: Figure out a better way for this
+			MIME=$(xdg-mime query filetype "$EXEC")
+			echo $MIME
+				case "$MIME" in
+					audio/*) ICON=/usr/share/icons/Adwaita/scalable/mimetypes/audio-x-generic-symbolic.svg
+					;;
+					application/*) ICON=/usr/share/icons/Adwaita/scalable/mimetypes/application-x-executable-symbolic.svg
+					;;
+					image/*) ICON=/usr/share/icons/Adwaita/scalable/mimetypes/image-x-generic-symbolic.svg
+					;;
+					video/*) ICON=/usr/share/icons/Adwaita/scalable/mimetypes/video-x-generic-symbolic.svg
+					;;
+				esac
+			
+		fi
+fi
+###################################################################Figure out, whether it is a shell script and if yes execute it accordingly!#######################################################
+				if [[ "$EXEC" =~ ".sh" ]]; then 
+					SLASHNUMBER=$(echo $EXEC  | grep -ho '/' | wc -w)
+					((SLASHNUMBER++))
+					PFADSLASH=""   #variablen initialisierung
+    					PROGRAM="" && echo "found exec sh"
+					APPNAME=./$(echo $EXEC | cut -d/ -f$(($SLASHNUMBER)))
+					echo $APPNAME
+					i=0
+					((SLASHNUMBER--))
+					while [ $i -lt $SLASHNUMBER ]
+						 do   
+							((i++))
+							PFADSLASH=$PFADSLASH$i,
+							echo $PFADSLASH
+						 done
+					PFADSLASH=$(echo $PFADSLASH | sed 's/,$//')
+					echo $PFADSLASH
+					PFAD=$(echo $EXEC | cut -d/ -f$PFADSLASH);
+					echo $PFAD
+					EXEC=$PFAD/$APPNAME			
+					TERMINAL=true
+					ICON=/usr/share/icons/Adwaita/scalable/mimetypes/application-x-executable-symbolic.svg
+				fi
+###############################################################End of the shellscript section, why didn't I use xterm instead of all this, would ve been easier...#######################################	
+#create desktop file and fill it up, open the software with MIME-TYPE
+echo "creating .desktop file"
+touch ~/.local/share/applications/"$NAME".desktop 
+echo "file created"
+echo "[Desktop Entry]"                  >> ~/.local/share/applications/"$NAME".desktop 
+echo "Name="$NAME""               	>> ~/.local/share/applications/"$NAME".desktop 
+echo "Exec=$PROGRAM${EXEC// /\\ }"      >> ~/.local/share/applications/"$NAME".desktop 
+echo "Icon=${ICON// /\\ }"              >> ~/.local/share/applications/"$NAME".desktop 
+echo "Terminal=$TERMINAL"               >> ~/.local/share/applications/"$NAME".desktop 
+echo "Type=Application"                 >> ~/.local/share/applications/"$NAME".desktop 
+echo "file creation done"
+
+#set the executable bit
+chmod +x $HOME/.local/share/applications/"$NAME".desktop
+echo "file created"
+
+zenity --info --text "File created!"
+
+exit 1
+


### PR DESCRIPTION
As discussed in [in this comment](https://www.reddit.com/r/linuxmasterrace/comments/rch8en/comment/hnvo07w/?utm_source=reddit&utm_medium=web2x&context=3), here is my version of an improved app adder script.

The major differences to yours are:
- It provides a simple GUI via zenity
- It has the ability to chose an icon
- It has the ability to determine the application type and is able to use the appropriate program to open the file. This is useful if for instance a user wants to add a shortcut for an image to the menu. The Desktop environment of the user has to follow the freedesktop specifications (XDG-mime as a dependency) for this to work.
- It has the abillity to add shell scripts as menu files, it fails for python and other scripts though

Usage: start the script, type in a name, select which file should be added. The icon choosing is optional, you can close it or click cancel and then it should determine a default icon. Only works if the Adwaita theme is installed so far (GNOME), if it isn't then another icon is used.

This script is more then 2 years old, so the code has some problems. Don't know if I am willing to make major changes to this again, but we can discuss this. Also one Bug that this script definitely has right now is that right now the user can't select an icon for a sh file (or rather the user choice is overridden), but this is easy to fix.

I can think about making this command line only, or you do it. Anyway I will leave that here for now, if you don't wanna use, maybe you can take some inspiration for future scripts from it. 

Always open for discussion.
Regards,
G.Schümann